### PR TITLE
Bug in notes fixed: When in edit mode, and close newly added note but…

### DIFF
--- a/src/app/note/note.component.html
+++ b/src/app/note/note.component.html
@@ -10,7 +10,7 @@
                    [style.visibility]="isActive?'visible':'hidden'"
     >
     </movable-point>
-    <kill-me [style.visibility]="isActive?'visible':'hidden'" (click)="killMe()"></kill-me>
+    <kill-me [style.visibility]="isActive?'visible':'hidden'" (click)="killMe($event)"></kill-me>
         <div class="note-content-wrapper"
             setColors [dBgColor]="bgColor" 
             [shouldSetBgColor]="false"

--- a/src/app/note/note.component.ts
+++ b/src/app/note/note.component.ts
@@ -80,7 +80,8 @@ export class NoteComponent implements OnInit {
     })
   }
 
-  killMe(){
+  killMe(event: any){
+    event.stopPropagation();
     this.messenger.inform('killMe', this.uniqueId)
   }
 


### PR DESCRIPTION
…ton was clicked, instead of closing note, new note was added. It was not behavior user whould expect, as other notes features like movement, resize and editing are working in edit mode. After investigation stopPropagation() was added to close buton event