### PR TITLE
page tab menu behaviour imporved: focusout event, content editable st…

### DIFF
--- a/src/app/sheet/tab-menu/tab-menu.component.css
+++ b/src/app/sheet/tab-menu/tab-menu.component.css
@@ -1,4 +1,8 @@
+:host{
+    left: 0.6rem;
+}
 .tab-menu{
+    left: 0.6rem;
     position: relative;
     width: 100%;
     height: 1.4rem;

--- a/src/app/sheet/tab/tab.component.css
+++ b/src/app/sheet/tab/tab.component.css
@@ -14,14 +14,22 @@
     z-index: 1;
     transition: 0.3s;
     text-overflow: ellipsis; 
-    /*ellipsis will not */
-    /* max-height: 1.2rem;
-    line-height: 1.1rem; */
+}
+.tab-shape>span{
+    width: 100%;
+    position: relative;
+    display: inline-block;
+}
+/* .tab-shape>span>span{ */
+.title-holder{
+    width: calc( 100% - 1rem );
+    position: relative;
+    display: inline-block;
 }
 .active{
     z-index: 100;
     font-weight: bold;
-    cursor: not-allowed;
+    cursor: cell;
 }
 
 .active-behind{
@@ -75,6 +83,8 @@
 .kill-me{
     position: relative;
     display: inline-block;
+    width: 1rem;
+    height: 1rem;
     transition: 0.3s;
     cursor: pointer;
     margin-left: 0.3rem;
@@ -83,4 +93,10 @@
 .kill-me:active{
     transition: 0.3;
     transform: scale(0.8);
+}
+.content-editable{
+    background-color: white;
+    color: black;
+    cursor: text;
+    outline: none;
 }

--- a/src/app/sheet/tab/tab.component.html
+++ b/src/app/sheet/tab/tab.component.html
@@ -6,6 +6,7 @@
         [style.border-bottom-color]="bgColor">
         <span>
             <span class = "title-holder" [attr.contenteditable]="inTitleEditMode"
+            [ngClass] = "{'content-editable':inTitleEditMode}"
             PreventEnter
             PreventPaste
             ValidateMenuTab

--- a/src/app/sheet/tab/tab.component.ts
+++ b/src/app/sheet/tab/tab.component.ts
@@ -45,9 +45,11 @@ export class TabComponent implements OnInit {
     this.tabChosen.emit(this.uniqueId)
   }
   @HostListener('dblclick', ['$event'])
-  enterChangeTitleMode(evetn: any){
-    evetn.stopPropagation();
+  enterChangeTitleMode(event: any){
+    event.stopPropagation();
     this.inTitleEditMode = true;
+    event.target.contentEditable = true;
+    event.target.focus();
   }
   @HostListener('focusout', ['$event'])
     exitChangeTitleMode(event: any){

--- a/src/styles.css
+++ b/src/styles.css
@@ -9,6 +9,7 @@ body, html{
     height: 100%;
     width: 100%;
     margin: 0;
+    background-color: rgb(210, 210, 230);
 }
 center{
     display: flex;


### PR DESCRIPTION
…yling, kill-me crosses alligned to right, whole menu moved to right so left side of trapeise does not overlap with left menu